### PR TITLE
Validate NodeJS dependencies on release

### DIFF
--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -37,6 +37,10 @@ release:
   filter:
     owner: vaticle
     branch: master
+  validation:
+    validate-dependencies:
+      image: vaticle-ubuntu-20.04
+      command: bazel test //:release-validate-nodejs-deps --test_output=streamed
   deployment:
     deploy-github-mac-windows:
       image: vaticle-ubuntu-20.04

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -18,6 +18,7 @@
 # NOTE: this file needs to be called `BUILD.bzl` to avoid conflicts with `build/` expected by electron-builder
 
 load("@vaticle_dependencies//distribution:deployment.bzl", "deployment")
+load("@vaticle_dependencies//tool/release:rules.bzl", "release_validate_nodejs_deps")
 load("@vaticle_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
 load("@vaticle_bazel_distribution//common:rules.bzl", "checksum")
 load("@vaticle_bazel_distribution//github:rules.bzl", "deploy_github")
@@ -101,6 +102,12 @@ checkstyle_test(
     include = glob(["*", ".grabl/*", ".circleci/*"]),
     exclude = glob([".circleci/windows/*", "build/**", "public/**", "typedb-client/**", "package.json", "package-lock.json", "dist_electron/**/*"]),
     license_type = "agpl",
+)
+
+release_validate_nodejs_deps(
+    name = "release-validate-nodejs-deps",
+    package_json = "//:package.json",
+    tagged_deps = ["typedb-client"]
 )
 
 # CI targets that are not declared in any BUILD file, but are called externally

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -32,6 +32,10 @@ load("@vaticle_dependencies//builder/nodejs:deps.bzl", nodejs_deps = "deps")
 nodejs_deps()
 load("@build_bazel_rules_nodejs//:index.bzl", "node_repositories", "npm_install")
 
+# Load //builder/java
+load("@vaticle_dependencies//builder/java:deps.bzl", java_deps = "deps")
+java_deps()
+
 # Load Python
 load("@vaticle_dependencies//builder/python:deps.bzl", python_deps = "deps")
 python_deps()
@@ -40,6 +44,9 @@ pip_install(
     name = "vaticle_dependencies_ci_pip",
     requirements = "@vaticle_dependencies//tool:requirements.txt",
 )
+
+# Load //tool/common
+load("@vaticle_dependencies//tool/common:deps.bzl", vaticle_dependencies_tool_maven_artifacts = "maven_artifacts")
 
 # Load Kotlin
 load("@vaticle_dependencies//builder/kotlin:deps.bzl", kotlin_deps = "deps")
@@ -94,6 +101,14 @@ npm_install(
     package_json = "//:package.json",
     package_lock_json = "//:package-lock.json",
 )
+
+############################
+# Load @maven dependencies #
+############################
+
+load("@vaticle_dependencies//library/maven:rules.bzl", "maven")
+maven(vaticle_dependencies_tool_maven_artifacts)
+
 
 ###############################################
 # Create @vaticle_typedb_workbase_workspace_refs #


### PR DESCRIPTION
## What is the goal of this PR?

Validate that released Workbase depends on a proper version of TypeDB Client NodeJS

## What are the changes implemented in this PR?

Add `//:release-validate-nodejs-deps` to validate `typedb-client` dependency