### PR TITLE
Upgrade from deprecated version of XCode image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ commands:
 jobs:
   deploy-mac-and-brew:
     macos:
-      xcode: "10.2.1"
+      xcode: "13.0.0"
     working_directory: ~/typedb-workbase
     steps:
       - install-bazel-mac


### PR DESCRIPTION
## What is the goal of this PR?

As CircleCI is going to deprecate (and eventually delete) the old image we're using for building & testing on macOS, we need to upgrade it.

## What are the changes implemented in this PR?

Bump version of XCode used for testing & building on macOS